### PR TITLE
Debug from Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,5 @@ If you want to use the debugging functions you will also need to setup a launch.
 
 ### Quirks & Known issues
 - Only 1 executable is supported right now
-- CppUTest does not let me change the output path of the JUnit file which I use to generate results (line numbers, etc.). Therefore they polute the executable directory
 - I am a developer and I write bugs. So there must be plenty in here!
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,5 @@ If you want to use the debugging functions you will also need to setup a launch.
 ### Quirks & Known issues
 - Only 1 executable is supported right now
 - CppUTest does not let me change the output path of the JUnit file which I use to generate results (line numbers, etc.). Therefore they polute the executable directory
-- Somehow line number and file information are not propagated to the Test Explorer. I am on it.
 - I am a developer and I write bugs. So there must be plenty in here!
 

--- a/src/CppUTestImplementation.ts
+++ b/src/CppUTestImplementation.ts
@@ -1,7 +1,6 @@
 import { TestSuiteInfo, TestInfo } from 'vscode-test-adapter-api';
 
-export class CppUTestGroup implements TestSuiteInfo 
-{
+export class CppUTestGroup implements TestSuiteInfo {
     type: "suite";
     id: string;
     label: string;
@@ -11,64 +10,59 @@ export class CppUTestGroup implements TestSuiteInfo
     line?: number | undefined;
     children: (TestSuiteInfo | TestInfo)[];
 
-    constructor(inputString: string)
-    {
+    constructor(inputString: string) {
         this.type = "suite";
         this.id = inputString;
         this.label = inputString;
         this.children = new Array<CppUTest | CppUTestGroup>();
     }
 
-    addTest(inputString: string)
+    addTest(inputString: string, file?: string, line?: number)
     {
         if(inputString.indexOf("."))
         {
             const stringSplit = inputString.split(".");
             if(stringSplit[0] === this.label)
             {
-                this.children.push(new CppUTest(stringSplit[1], stringSplit[0]));
+                const test: CppUTest = new CppUTest(stringSplit[1], stringSplit[0])
+                test.file = file;
+                test.line = line;
+                this.children.push(test);
             }
         }
     }
 
-    findTest(label: string): CppUTest | undefined
-    {
-        if(label.indexOf("."))
-        {
+    findTest(label: string): CppUTest | undefined {
+        if (label.indexOf(".")) {
             return this.Tests.find(t => t.id === label)
         }
         return undefined;
     }
 
-    updateTest(test: CppUTest)
-    {
+    updateTest(test: CppUTest) {
         let oldTest: CppUTest | undefined = this.findTest(test.label);
-        if(oldTest)
-        {
+        if (oldTest) {
             oldTest = test;
         }
     }
 
-    get Tests(): CppUTest[]
-    {
+    get Tests(): CppUTest[] {
         const retVal: CppUTest[] = new Array<CppUTest>();
         this.children.forEach(c => {
-            if(c instanceof CppUTest){
+            if (c instanceof CppUTest) {
                 retVal.push(c);
-            } 
-            else
-            {
+            }
+            else {
                 retVal.push(...(<CppUTestGroup>c).Tests);
             }
         })
         return retVal;
     }
 
-    get TestGroups(): CppUTestGroup[]
-    {
+    get TestGroups(): CppUTestGroup[] {
         const retVal: CppUTestGroup[] = new Array<CppUTestGroup>();
         this.children.forEach(c => {
-            if(c instanceof CppUTestGroup){
+            if (c instanceof CppUTestGroup) {
                 retVal.push(c);
             }
         })
@@ -76,9 +70,8 @@ export class CppUTestGroup implements TestSuiteInfo
     }
 }
 
-export class CppUTest implements TestInfo
-{
-    type: "test";    
+export class CppUTest implements TestInfo {
+    type: "test";
     id: string;
     label: string;
     description?: string | undefined;
@@ -87,11 +80,12 @@ export class CppUTest implements TestInfo
     line?: number | undefined;
     skipped?: boolean | undefined;
 
-    
-    constructor(testString: string, groupString: string)
-    {
+
+    constructor(testString: string, groupString: string) {
         this.type = "test";
         this.id = groupString + "." + testString;
         this.label = testString;
-    }  
+        this.file = "C:\\Users\\benni\\Documents\\CppUTest-Test-Adapter\\test\\basicTests.cpp";
+        this.line = 50;
+    }
 }

--- a/src/CppUTestImplementation.ts
+++ b/src/CppUTestImplementation.ts
@@ -85,7 +85,5 @@ export class CppUTest implements TestInfo {
         this.type = "test";
         this.id = groupString + "." + testString;
         this.label = testString;
-        this.file = "C:\\Users\\benni\\Documents\\CppUTest-Test-Adapter\\test\\basicTests.cpp";
-        this.line = 50;
     }
 }

--- a/src/cpputest.ts
+++ b/src/cpputest.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 import { exec, execFile, ChildProcess } from 'child_process';
-import { TestSuiteInfo, TestInfo, TestRunStartedEvent, TestRunFinishedEvent, TestSuiteEvent, TestEvent, TestDecoration } from 'vscode-test-adapter-api';
+import { TestSuiteInfo, TestInfo, TestRunStartedEvent, TestRunFinishedEvent, TestSuiteEvent, TestEvent } from 'vscode-test-adapter-api';
 import { CppUTest, CppUTestGroup } from './CppUTestImplementation';
-import * as xml2js from 'xml2js';
-import * as fs from 'fs';
 import * as pathModule from 'path';
 
 let suite: CppUTestGroup;
@@ -29,11 +27,9 @@ export function loadTests(): Promise<TestSuiteInfo> {
             suite.children.push(subSuite);
             groups.forEach(g => subSuite.children.push(new CppUTestGroup(g)));
 
-            for(let i: number = 0; i < groupStrings.length; i++)
-            {
+            for (let i: number = 0; i < groupStrings.length; i++) {
                 const gs = groupStrings[i];
-                for(let j: number = 0; j < subSuite.TestGroups.length; j++)
-                {
+                for (let j: number = 0; j < subSuite.TestGroups.length; j++) {
                     const tg: CppUTestGroup = subSuite.TestGroups[j];
                     const group = gs.split(".")[0];
                     const test = gs.split(".")[1];
@@ -51,22 +47,21 @@ export function loadTests(): Promise<TestSuiteInfo> {
     return Promise.resolve<TestSuiteInfo>(promise);
 }
 
-async function getLineAndFile(command: string, path: string, group: string, test: string): Promise<{file?: string, line?: number}>
-{
+async function getLineAndFile(command: string, path: string, group: string, test: string): Promise<{ file?: string, line?: number }> {
     // Linux:
     const sourceGrep = `objdump -lSd ${command} | grep -m 1 -A 2 TEST_${group}_${test}`;
     // Windows:
     // const sourceGrep = `windObjDumpOrWhatEver ${command} | findstr TEST_${group}_${test}`
-    return new Promise<{file?: string, line?: number}>((resolve, reject) => {
+    return new Promise<{ file?: string, line?: number }>((resolve, reject) => {
         exec(sourceGrep, { cwd: path }, (error, stdout, stderr) => {
             if (error) {
                 console.error('stderr', error.cmd);
-                resolve({file: undefined, line: undefined});
+                resolve({ file: undefined, line: undefined });
             } else {
                 const debugSymbols: string[] = stdout.split("\n")[2].split(":");
                 const file = debugSymbols[0];
                 const line = parseInt(debugSymbols[1], 10) - 2; // show it above the test
-                resolve({file, line});
+                resolve({ file, line });
             }
         });
     })
@@ -90,8 +85,7 @@ export function killTestRun() {
 
 export async function debugTest(tests: string[]) {
     const config = getDebugConfiguration();
-    if(config === "")
-    {
+    if (config === "") {
         throw new Error("No debug configuration found. Not able to debug!");
     }
     for (const suiteOrTestId of tests) {
@@ -100,8 +94,7 @@ export async function debugTest(tests: string[]) {
             (config as any).name = node.id;
             const arg: string = node.id.search(/\./) >= 0 ? "-t" : "-sg";
             (config as any).args = [arg, node.id];
-            if(vscode.workspace.workspaceFolders)
-            {
+            if (vscode.workspace.workspaceFolders) {
                 await vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], config);
             }
         }
@@ -152,79 +145,42 @@ async function runNode(
 
 async function runSingleCall(command: string, group: string, test: string, path: string) {
     const promise: Promise<TestEvent> = new Promise<TestEvent>((resolve, reject) => {
-        const runProcess: ChildProcess = execFile(command, ["-sg", group, "-sn", test, "-ojunit"], { cwd: path }, (error: any, stdout, stderr) => {
+        const runProcess: ChildProcess = execFile(command, ["-sg", group, "-sn", test, "-v"], { cwd: path }, (error: any, stdout, stderr) => {
             if (error && error.code === null) {
                 resolve(Promise.resolve(<TestEvent>{ type: 'test', test: suite.findTest(group + "." + test), state: 'errored', message: stderr }));
                 return;
             }
-            resolve(evaluateXML(group, path));
+            const regexPattern: RegExp = /(\w*)_*TEST\((\w*), (\w*)\)(.*?)- (\d*) ms/gs;
+            const result: RegExpExecArray | null = regexPattern.exec(stdout)
+            if (result == null) {
+                reject({ "reason": "unkown" });
+            }
+            else {
+                let state: TestEvent["state"] = "passed";
+                if (result[1] == "IGNORE_") {
+                    state = "skipped";
+                }
+                if(result[4].trim())
+                {
+                    state = "failed";
+                }
+                console.log(result);
+                const event: TestEvent = {
+                    type: 'test',
+                    test: new CppUTest(test, group),
+                    state: state,
+                    message: result[4].trim(),
+                    decorations: undefined
+                }
+                console.log(event);
+                resolve(event);
+            }
         });
         processes.push(runProcess);
     });
     return Promise.resolve(promise);
 }
 
-async function evaluateXML(
-    group: string,
-    path: string) {
-    const parser: xml2js.Parser = new xml2js.Parser();
-    path = path == "" ? "." : path;
-    const fileName: string = path + "/cpputest_" + group + ".xml";
-    if (!fs.existsSync(fileName)) {
-        return Promise.resolve(<TestEvent>{ type: 'test', test: group, state: 'errored', message: "Test crashed" })
-    }
-    const xml: Buffer = fs.readFileSync(fileName);
-    const promise: Promise<TestEvent> = new Promise<TestEvent>((resolve, reject) => {
-        parser.parseString(xml, function (err: string, result: any) {
-            if (err) {
-                reject(err);
-            } else {
-                const tc: any = result.testsuite.testcase[0];
-                const testName: string = tc.$.name;
-                const testGroup: string = tc.$.classname;
-                const testFile: string = tc.$.file;
-                const testLine: number = Number.parseInt(tc.$.line);
-                let state: TestEvent["state"];
-                if (tc.failure) {
-                    state = "failed";
-                }
-                else if (tc.skipped) {
-                    state = "skipped";
-                }
-                else {
-                    state = "passed";
-                }
-                let message: string = "";
-                let decoration: TestDecoration[] | undefined = undefined;
-                if (state === "failed") {
-                    const failure: any = tc.failure[0].$;
-                    message = failure.message.replace(/\{newline\}/g, "\n");
-                    decoration = [
-                        {
-                            line: Number.parseInt(message.split(":")[1]),
-                            message: message.split(":")[2]
-                        }
-                    ];
-                }
-
-                const testInfo = new CppUTest(testName, testGroup);
-                const path: string = getTestPath();
-                testInfo.file = path + testFile;
-                testInfo.line = testLine;
-                suite.updateTest(testInfo);
-                const event: TestEvent = {
-                    type: 'test',
-                    test: testInfo,
-                    state: state,
-                    message: message,
-                    decorations: decoration
-                }
-                resolve(event);
-            }
-        });
-    })
-    return Promise.resolve(promise);
-}
 
 export function getTestRunner(): string {
     const runner: string | undefined = vscode.workspace.getConfiguration("cpputestExplorer").testExecutable;
@@ -278,10 +234,14 @@ function getDebugConfiguration(): (vscode.DebugConfiguration | string) {
     return "";
 }
 
-function IsCCppDebugger(config: any){
+function IsCCppDebugger(config: any) {
+    const isWin = process.platform === "win32";
+    // This is my way of saying: If we are using windows check for a config that has an .exe program.
+    const executionExtension: boolean = isWin ? config.program.endsWith(".exe") : true;
     return config.request == 'launch' &&
         typeof config.type == 'string' &&
+        executionExtension &&
         (config.type.startsWith('cpp') ||
-         config.type.startsWith('lldb') ||
-         config.type.startsWith('gdb'));
+            config.type.startsWith('lldb') ||
+            config.type.startsWith('gdb'));
 }


### PR DESCRIPTION
- Using linux build tools to grep the symbol file for debug information.
- Also using regexp instead of XML parsing to get test results
Fixes #9