### PR TITLE
CTA-1: Fix pulling debug info for UI Display

### DIFF
--- a/src/cpputest.ts
+++ b/src/cpputest.ts
@@ -49,7 +49,7 @@ export function loadTests(): Promise<TestSuiteInfo> {
 
 async function getLineAndFile(command: string, path: string, group: string, test: string): Promise<{ file?: string, line?: number }> {
     // Linux:
-    const sourceGrep = `objdump -lSd ${command} | grep -m 1 -A 2 TEST_${group}_${test}`;
+    const sourceGrep = `objdump -lSd ${command} | grep -m 2 -A 2 TEST_${group}_${test}`;
     // Windows:
     // const sourceGrep = `windObjDumpOrWhatEver ${command} | findstr TEST_${group}_${test}`
     return new Promise<{ file?: string, line?: number }>((resolve, reject) => {


### PR DESCRIPTION
Currently there is a small bug pulling the correct lines from the objdump to pull the name of the test.  There is a grep that is not pulling enough lines.
The fix changes the number of lines being pulled so that the UI can be correctly poplulated.