### PR TITLE
CTA-15: Reorder Tests by File Order

### DIFF
--- a/src/CppUTestImplementation.ts
+++ b/src/CppUTestImplementation.ts
@@ -27,7 +27,7 @@ export class CppUTestGroup implements TestSuiteInfo {
                 const test: CppUTest = new CppUTest(stringSplit[1], stringSplit[0])
                 test.file = file;
                 test.line = line;
-                this.children.push(test);
+                this.children.unshift(test);
             }
         }
     }


### PR DESCRIPTION
resolves #15 

Currently the UI display shows tests in reverse order.
    
This change shows the tests in the order they are arranged within the test file.