### PR TITLE
Full reload before running

### DIFF
--- a/src/Domain/CppUTest.ts
+++ b/src/Domain/CppUTest.ts
@@ -1,5 +1,4 @@
 import { TestInfo } from "vscode-test-adapter-api";
-import uuid from "./uuid";
 
 export class CppUTest implements TestInfo {
   type: "test" = "test";
@@ -12,11 +11,21 @@ export class CppUTest implements TestInfo {
   line?: number | undefined;
   skipped?: boolean | undefined;
 
-  constructor(testString: string, group: string, file?: string | undefined, line?: number | undefined) {
-    this.id = uuid();
+  constructor(testString: string, group: string, id: string, file?: string | undefined, line?: number | undefined) {
+    this.id = id;
     this.file = file;
     this.line = line;
     this.label = testString;
     this.group = group;
+  }
+
+  public AddDebugInformation(testDebugString: string): void {
+    const symbolInformationLines = testDebugString.split("\n");
+    const filePath = symbolInformationLines.filter(si => si.startsWith("/"))[0];
+    const debugSymbols: string[] = filePath.split(":");
+    const file = debugSymbols[0];
+    const line = parseInt(debugSymbols[1], 10);
+    this.file = file;
+    this.line = line;
   }
 }

--- a/src/Domain/CppUTestContainer.ts
+++ b/src/Domain/CppUTestContainer.ts
@@ -11,7 +11,7 @@ import { VscodeAdapter } from "../Infrastructure/VscodeAdapter";
 
 export default class CppUTestContainer {
   private runners: ExecutableRunner[];
-  private suites: Map<string, CppUTestGroup>;
+  private suites: Map<string, CppUTestSuite>;
   private settingsProvider: SettingsProvider;
   private vscodeAdapter: VscodeAdapter;
   private resultParser: ResultParser;
@@ -30,25 +30,24 @@ export default class CppUTestContainer {
     this.runners = runners;
     this.vscodeAdapter = vscodeAdapter;
     this.resultParser = resultParser;
-    this.suites = new Map<string, CppUTestGroup>();
+    this.suites = new Map<string, CppUTestSuite>();
   }
 
-  public LoadTests(): Promise<CppUTestGroup[]> {
+  public LoadTests(): Promise<CppUTestSuite[]> {
     return Promise.all(this.runners
       .map(runner => runner.GetTestList()
-        .then(testString => this.EmbedInRunnerGroup(runner, testString))
+        .then(testString => this.UpdateTestSuite(runner, testString))
         .catch(error => new CppUTestGroup("ERROR ON LOADING TESTS"))
       ));
   }
 
   public ClearTests() {
-    this.suites = new Map<string, CppUTestGroup>();
+    this.suites = new Map<string, CppUTestSuite>();
   }
 
   public async RunAllTests(): Promise<TestResult[]> {
-    const testList = await this.LoadTests();
     const testResults: TestResult[] = new Array<TestResult>();
-    for (const executableGroup of testList) {
+    for (const executableGroup of this.suites.values()) {
       for (const testGroup of executableGroup.children) {
         for (const test of (testGroup as CppUTestGroup).children) {
           const runner = this.runners.filter(r => r.Name === executableGroup.label)[0];
@@ -64,10 +63,9 @@ export default class CppUTestContainer {
   }
 
   public async RunTest(...testId: string[]): Promise<TestResult[]> {
-    const testList = await this.LoadTests();
     const testResults: TestResult[] = new Array<TestResult>();
     const testsToRun: CppUTest[] = new Array<CppUTest>();
-    for (const executableGroup of testList) {
+    for (const executableGroup of this.suites.values()) {
       testsToRun.splice(0, testsToRun.length);
       if (testId.includes(executableGroup.id)) {
         testsToRun.push(...executableGroup.Tests);
@@ -106,8 +104,7 @@ export default class CppUTestContainer {
     if (!workspaceFolders) {
       throw new Error("No workspaceFolders found. Not able to debug!");
     }
-    const testList = await this.LoadTests();
-    for (const executableGroup of testList) {
+    for (const executableGroup of this.suites.values()) {
       const testOrGroup = this.GetGroupOrTest(testId, executableGroup);
       const runner = this.runners.filter(r => r.Name === executableGroup.label)[0];
       if (testOrGroup && runner) {
@@ -147,21 +144,27 @@ export default class CppUTestContainer {
     return Array<CppUTest>().concat(...tests);
   }
 
-  private async EmbedInRunnerGroup(runner: ExecutableRunner, testString: string): Promise<CppUTestGroup> {
-    if (this.suites.has(runner.Name)) {
-      return (this.suites.get(runner.Name) as CppUTestGroup);
-    }
-    const testFactory = new CppUTestSuite(runner.Name);
-    const testGroup = testFactory.CreateTestGroupsFromTestListString(testString);
-    for(const test of testGroup.Tests) {
+  private async UpdateTestSuite(runner: ExecutableRunner, testString: string): Promise<CppUTestSuite> {
+    const testSuite = this.GetTestSuite(runner.Name);
+    testSuite.UpdateFromTestListString(testString);
+    for(const test of testSuite.Tests) {
       try {
         const debugString = await runner.GetDebugSymbols(test.group, test.label);
-        testFactory.AddDebugInformationToTest(test, debugString);
+        test.AddDebugInformation(debugString);
       } catch (error) {
         console.error(error);
       }
     }
-    this.suites.set(runner.Name, testGroup);
-    return testGroup;
+    return testSuite;
+  }
+
+  private GetTestSuite(runnerName: string): CppUTestSuite {
+    if (this.suites.has(runnerName)) {
+      return (this.suites.get(runnerName) as CppUTestSuite);
+    } else {
+      const testSuite = new CppUTestSuite(runnerName);
+      this.suites.set(runnerName, testSuite);
+      return testSuite;
+    }
   }
 }

--- a/src/Domain/CppUTestContainer.ts
+++ b/src/Domain/CppUTestContainer.ts
@@ -37,7 +37,7 @@ export default class CppUTestContainer {
     return Promise.all(this.runners
       .map(runner => runner.GetTestList()
         .then(testString => this.UpdateTestSuite(runner, testString))
-        .catch(error => new CppUTestGroup("ERROR ON LOADING TESTS"))
+        .catch(error => this.CreateTestSuiteError(runner.Name))
       ));
   }
 
@@ -155,6 +155,12 @@ export default class CppUTestContainer {
         console.error(error);
       }
     }
+    return testSuite;
+  }
+
+  private async CreateTestSuiteError(runnerName: string): Promise<CppUTestSuite> {
+    const testSuite = this.GetTestSuite(runnerName);
+    testSuite.AddTestGroup("ERROR LOADING TESTS");
     return testSuite;
   }
 

--- a/src/Domain/CppUTestGroup.ts
+++ b/src/Domain/CppUTestGroup.ts
@@ -1,7 +1,5 @@
-import { TestSuiteInfo, TestInfo } from 'vscode-test-adapter-api';
+import { TestSuiteInfo } from 'vscode-test-adapter-api';
 import { CppUTest } from "./CppUTest";
-import uuid from './uuid';
-
 
 export class CppUTestGroup implements TestSuiteInfo {
     type: "suite";
@@ -11,20 +9,24 @@ export class CppUTestGroup implements TestSuiteInfo {
     tooltip?: string | undefined;
     file?: string | undefined;
     line?: number | undefined;
-    children: (TestSuiteInfo | TestInfo)[];
-    executable: string | undefined;
+    children: (CppUTest | CppUTestGroup)[];
 
-    constructor(inputString: string, executable: string | undefined = undefined) {
+    constructor(label: string, id: string) {
         this.type = "suite";
-        this.id = uuid();
-        this.label = inputString;
+        this.id = id;
+        this.label = label;
         this.children = new Array<CppUTest | CppUTestGroup>();
-        this.executable = executable;
     }
 
     AddTest(testName: string, file?: string, line?: number) {
-        const test: CppUTest = new CppUTest(testName, this.label, file, line);
+        const test: CppUTest = new CppUTest(testName, this.label, this.id + "/" + testName, file, line);
         this.children.unshift(test);
+    }
+
+    AddTestGroup(groupName: string): CppUTestGroup {
+        const testGroup = new CppUTestGroup(groupName, this.id + "/" + groupName);
+        this.children.push(testGroup);
+        return testGroup;
     }
 
     FindTest(id: string): CppUTest[] {

--- a/tests/CppUTest.spec.ts
+++ b/tests/CppUTest.spec.ts
@@ -1,21 +1,55 @@
 import { expect } from "chai";
 import { CppUTest } from "../src/Domain/CppUTest";
 
+const symbolStrings = [
+  {
+    test: new CppUTest("test1", "group1", "id1"),
+    value:
+      "_ZN31TEST_Group1_Test1_TestShellC4Ev():\n" +
+      "/tmp/myPath/basicTests.cpp:56\n" +
+      "randomly placed line that confuses the analyzer\n" +
+      "TEST(Group1, Test1)\n" +
+      "random information that is not correlated at all"
+  },
+  {
+    test: new CppUTest("test2", "group1", "id2"),
+    value:
+      "_ZN31TEST_Group1_Test1_TestShellC4Ev():\n" +
+      "randomly placed line that confuses the analyzer\n" +
+      "/tmp/myPath/basicTests.cpp:56\n" +
+      "TEST(Group1, Test1)\n" +
+      "random information that is not correlated at all"
+  },
+  {
+    test: new CppUTest("test3", "group1", "id3"),
+    value:
+      "/tmp/myPath/basicTests.cpp:56"
+  }
+];
+
 describe("CppUTest should", () => {
   it("be creatable with all information", () => {
-    const test = new CppUTest("TestName", "GroupName", "file.cpp", 53);
+    const test = new CppUTest("TestName", "GroupName", "TestName/GroupName", "file.cpp", 53);
     expect(test.label).to.be.equal("TestName");
-    expect(test.id).to.contain("-");
+    expect(test.id).to.be.equal("TestName/GroupName");
     expect(test.file).to.be.equal("file.cpp");
     expect(test.line).to.be.equal(53);
   })
 
   it("be creatable with basic information", () => {
-    const test = new CppUTest("TestName", "GroupName");
+    const test = new CppUTest("TestName", "GroupName", "TestName/GroupName");
     expect(test.label).to.be.equal("TestName");
     expect(test.group).to.be.equal("GroupName");
-    expect(test.id).to.contain("-");
+    expect(test.id).to.contain("TestName/GroupName");
     expect(test.file).to.be.equal(undefined);
     expect(test.line).to.be.equal(undefined);
   })
+
+  symbolStrings.forEach(symbolString =>
+    it(`create debug information from symbol definition string for ${symbolString.test.label}`, () => {
+      symbolString.test.AddDebugInformation(symbolString.value);
+      expect(symbolString.test.file).to.be.equal("/tmp/myPath/basicTests.cpp");
+      expect(symbolString.test.line).to.be.equal(56);
+    })
+  )
 });

--- a/tests/CppUTestContainer.spec.ts
+++ b/tests/CppUTestContainer.spec.ts
@@ -50,7 +50,7 @@ describe("CppUTestContainer should", () => {
     const testList1 = await container.LoadTests();
     container.ClearTests()
     const testList2 = await container.LoadTests();
-    expect(JSON.stringify(testList1)).to.be.not.eq(JSON.stringify(testList2));
+    expect(JSON.stringify(testList1)).to.be.eq(JSON.stringify(testList2));
   })
 
   it("get the same id on consecutive loads", async () => {

--- a/tests/CppUTestGroup.spec.ts
+++ b/tests/CppUTestGroup.spec.ts
@@ -5,12 +5,12 @@ import { CppUTestGroup } from "../src/Domain/CppUTestGroup";
 describe("CppUTestGroup should", () => {
   let testGroup: CppUTestGroup;
   beforeEach(() => {
-    testGroup = new CppUTestGroup("TestName");
+    testGroup = new CppUTestGroup("TestGroup", "TestGroupId");
   })
 
   it("be creatable with all information", () => {
-    expect(testGroup.label).to.be.equal("TestName");
-    expect(testGroup.id).to.contain("-");
+    expect(testGroup.label).to.be.equal("TestGroup");
+    expect(testGroup.id).to.be.equal("TestGroupId");
   })
   it("be able to add tests", () => {
     expect(testGroup.children.length).to.be.eq(0);
@@ -19,7 +19,7 @@ describe("CppUTestGroup should", () => {
   })
 
   it("find test by id", () => {
-    const test = new CppUTest("myTest", "myGroup");
+    const test = new CppUTest("myTest", "myGroup", "myId");
     const id = test.id;
     testGroup.children.push(test);
     testGroup.AddTest("randomTest1");
@@ -45,8 +45,8 @@ describe("CppUTestGroup should", () => {
   })
 
   it("find all tests in nested groups", () => {
-    const subTestGroup1 = new CppUTestGroup("subTestGroup1");
-    const subTestGroup2 = new CppUTestGroup("subTestGroup2");
+    const subTestGroup1 = new CppUTestGroup("subTestGroup1", "subTestGroupId1");
+    const subTestGroup2 = new CppUTestGroup("subTestGroup2", "subTestGroupId2");
     testGroup.children.push(subTestGroup1);
     testGroup.children.push(subTestGroup2);
     subTestGroup1.AddTest("test1");

--- a/tests/CppUTestSuite.spec.ts
+++ b/tests/CppUTestSuite.spec.ts
@@ -1,51 +1,17 @@
 import { expect } from 'chai';
-import { CppUTest } from '../src/Domain/CppUTest';
 import { CppUTestGroup } from '../src/Domain/CppUTestGroup';
 import CppUTestSuite from '../src/Domain/CppUTestSuite';
-
-const symbolStrings = [
-  {
-    test: new CppUTest("test1", "group1"),
-    value:
-      "_ZN31TEST_Group1_Test1_TestShellC4Ev():\n" +
-      "/tmp/myPath/basicTests.cpp:56\n" +
-      "randomly placed line that confuses the analyzer\n" +
-      "TEST(Group1, Test1)\n" +
-      "random information that is not correlated at all"
-  },
-  {
-    test: new CppUTest("test2", "group1"),
-    value:
-      "_ZN31TEST_Group1_Test1_TestShellC4Ev():\n" +
-      "randomly placed line that confuses the analyzer\n" +
-      "/tmp/myPath/basicTests.cpp:56\n" +
-      "TEST(Group1, Test1)\n" +
-      "random information that is not correlated at all"
-  },
-  {
-    test: new CppUTest("test3", "group1"),
-    value:
-      "/tmp/myPath/basicTests.cpp:56"
-  }
-];
 
 describe('CppUTestSuite should', () => {
   const suite = new CppUTestSuite("Label");
 
   it('create a TestSuite from an test list string', () => {
     const testListString = "Group1.Test1 Group1.Test2 Group2.Test1";
-    const testSuite = suite.CreateTestGroupsFromTestListString(testListString);
-    expect(testSuite.label).to.be.equal("Label");
-    expect(testSuite.children.length).to.be.eq(2);
-    expect(testSuite.children[0].label).to.be.equal("Group1");
-    expect(testSuite.children[1].label).to.be.equal("Group2");
-    expect((testSuite.children[0] as CppUTestGroup).children[0].label).to.be.equal("Test2");
+    suite.UpdateFromTestListString(testListString);
+    expect(suite.label).to.be.equal("Label");
+    expect(suite.children.length).to.be.eq(2);
+    expect(suite.children[0].label).to.be.equal("Group1");
+    expect(suite.children[1].label).to.be.equal("Group2");
+    expect((suite.children[0] as CppUTestGroup).children[0].label).to.be.equal("Test2");
   });
-
-  symbolStrings.forEach(symbolString =>
-    it(`create debug information from symbol definition string for ${symbolString.test.label}`, () => {
-      suite.AddDebugInformationToTest(symbolString.test, symbolString.value);
-      expect(symbolString.test.file).to.be.equal("/tmp/myPath/basicTests.cpp");
-      expect(symbolString.test.line).to.be.equal(56);
-    }))
 });


### PR DESCRIPTION
Implemented full reload of tests before running tests to enable automatic insertion of newly added tests and deletion of tests that do not exist anymore.

The performance impact is negligible since the test list was already being reloaded on every run.

Note: test and test group identifiers are now logical identifiers instead of UUIDs to avoid having to keep unique ids on reload.