### PR TITLE
Automatic settings reload and test executable detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This is the implementation for a [CppUTest](https://cpputest.github.io/) Test Ad
 
 ## Setup
 
-To let this plugin know where your tests are set the ```cpputestExplorer.testExecutable``` to the executable of your tests. They are separated by semicolon and support wildcards, so you can add as many executables as you want:
+To let this plugin know where your tests are set the ```cpputestTestAdapter.testExecutable``` to the executable of your tests. They are separated by semicolon and support wildcards, so you can add as many executables as you want:
 ```
 {
-  "cpputestExplorer.testExecutable": "${workspaceFolder}/test/testrunner;${workspaceFolder}/test/subFolder/ut_*",
-  "cpputestExplorer.testExecutablePath": "${workspaceFolder}/test"
+  "cpputestTestAdapter.testExecutable": "${workspaceFolder}/test/testrunner;${workspaceFolder}/test/subFolder/ut_*",
+  "cpputestTestAdapter.testExecutablePath": "${workspaceFolder}/test"
 }
 ```
-They will be executed in the ```cpputestExplorer.testExecutablePath``` path.
+They will be executed in the ```cpputestTestAdapter.testExecutablePath``` path.
 
 If you want to use the debugging functions you will also need to setup a launch.json file with your debugger path and arguments etc. The adapter will take care of the rest. Hopefully.
 

--- a/package.json
+++ b/package.json
@@ -68,27 +68,27 @@
   "contributes": {
     "configuration": {
       "type": "object",
-      "title": "CppUTest Explorer configuration",
+      "title": "CppUTest Test Adapter",
       "properties": {
-        "cpputestExplorer.testExecutable": {
-          "description": "executable that contains all tests. Can be multiple executables separated by semicolon. Wildcard is supported (e.g. myExecutable;bin/test/ut_*)",
+        "cpputestTestAdapter.testExecutable": {
+          "description": "Executable that contains all tests. Can be multiple executables separated by semicolon. Wildcard is supported (e.g. myExecutable;bin/test/ut_*)",
           "default": "",
           "type": "string",
           "scope": "resource"
         },
-        "cpputestExplorer.testExecutablePath": {
-          "description": "path where the executable should be run in",
+        "cpputestTestAdapter.testExecutablePath": {
+          "description": "Path where the executable should be run in",
           "default": "",
           "type": "string",
           "scope": "resource"
         },
-        "cpputestExplorer.logpanel": {
-          "description": "write diagnotic logs to an output panel",
+        "cpputestTestAdapter.logpanel": {
+          "description": "Write diagnostic logs to an output panel",
           "type": "boolean",
           "scope": "resource"
         },
-        "cpputestExplorer.logfile": {
-          "description": "write diagnostic logs to the given file",
+        "cpputestTestAdapter.logfile": {
+          "description": "Write diagnostic logs to the given file",
           "type": "string",
           "scope": "resource"
         }

--- a/src/Domain/CppUTestContainer.ts
+++ b/src/Domain/CppUTestContainer.ts
@@ -25,15 +25,16 @@ export default class CppUTestContainer {
     this.onTestStartHandler = handler;
   }
 
-  constructor(runners: ExecutableRunner[], settingsProvider: SettingsProvider, vscodeAdapter: VscodeAdapter, resultParser: ResultParser) {
+  constructor(settingsProvider: SettingsProvider, vscodeAdapter: VscodeAdapter, resultParser: ResultParser) {
     this.settingsProvider = settingsProvider;
-    this.runners = runners;
+    this.runners = [];
     this.vscodeAdapter = vscodeAdapter;
     this.resultParser = resultParser;
     this.suites = new Map<string, CppUTestSuite>();
   }
 
-  public LoadTests(): Promise<CppUTestSuite[]> {
+  public LoadTests(runners: ExecutableRunner[]): Promise<CppUTestSuite[]> {
+    this.runners = runners;
     return Promise.all(this.runners
       .map(runner => runner.GetTestList()
         .then(testString => this.UpdateTestSuite(runner, testString))

--- a/src/Infrastructure/VscodeSettingsProvider.ts
+++ b/src/Infrastructure/VscodeSettingsProvider.ts
@@ -3,12 +3,16 @@ import { glob } from 'glob';
 import { SettingsProvider } from './SettingsProvider';
 
 export default class VscodeSettingsProvider implements SettingsProvider {
-  private readonly Executables: string;
-  private readonly ExecutablePath: string;
+  private config: vscode.WorkspaceConfiguration;
 
-  constructor(config: vscode.WorkspaceConfiguration) {
-    this.Executables = config.testExecutable;
-    this.ExecutablePath = config.testExecutablePath;
+  constructor() {
+    const configSection = "cpputestTestAdapter";
+    this.config = vscode.workspace.getConfiguration(configSection);
+    vscode.workspace.onDidChangeConfiguration(event => {
+      if (event.affectsConfiguration(configSection)) {
+        this.config = vscode.workspace.getConfiguration(configSection);
+      }
+    })
   }
 
   GetWorkspaceFolders(): readonly vscode.WorkspaceFolder[] | undefined {
@@ -16,11 +20,11 @@ export default class VscodeSettingsProvider implements SettingsProvider {
   }
 
   public GetTestRunners(): string[] {
-    return this.SplitRunners(this.Executables);
+    return this.SplitRunners(this.config.testExecutable);
   }
 
   public GetTestPath(): string {
-    return this.ResolveSettingsVariable(this.ExecutablePath);
+    return this.ResolveSettingsVariable(this.config.testExecutablePath);
   }
 
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -37,7 +37,7 @@ export class CppUTestAdapter implements TestAdapter {
 
 		this.disposables.push(this.testsEmitter, this.testStatesEmitter, this.autorunEmitter);
 
-		const settingsProvider = new VscodeSettingsProvider(vscode.workspace.getConfiguration("cpputestExplorer"));
+		const settingsProvider = new VscodeSettingsProvider(vscode.workspace.getConfiguration("cpputestTestAdapter"));
 		const processExecuter = new NodeProcessExecuter();
 		const vscodeAdapter = new VscodeAdapterImplementation();
 		const runners = settingsProvider.GetTestRunners().map(runner => new ExecutableRunner(processExecuter, runner));

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	const workspaceFolder = (vscode.workspace.workspaceFolders || [])[0];
 
 	// create a simple logger that can be configured with the configuration variables
-	// `cpputestExplorer.logpanel"` and `cpputestExplorer.logfile`
-	const log = new Log('cpputestExplorer', workspaceFolder, 'CppUTest Explorer Log');
+	// `cpputestTestAdapter.logToOutputPanel"` and `cpputestTestAdapter.logToFile`
+	const log = new Log('cpputestTestAdapter', workspaceFolder, 'CppUTest Test Adapter Log');
 	context.subscriptions.push(log);
 
 	// get the Test Explorer extension

--- a/tests/CppUTestContainer.spec.ts
+++ b/tests/CppUTestContainer.spec.ts
@@ -31,9 +31,9 @@ describe("CppUTestContainer should", () => {
     const mockRunner1 = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
     const mockRunner2 = createMockRunner("Exec2", "Group4.Test1 Group5.Test2 Group5.Test42");
 
-    const container = new CppUTestContainer([instance(mockRunner1), instance(mockRunner2)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner1), instance(mockRunner2)]);
     expect(allTests).to.be.lengthOf(2);
     expect(allTests[0].label).to.be.eq("Exec1");
     expect(allTests[1].label).to.be.eq("Exec2");
@@ -46,26 +46,26 @@ describe("CppUTestContainer should", () => {
   })
 
   it("reload all tests after clear", async () => {
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
-    const testList1 = await container.LoadTests();
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const testList1 = await container.LoadTests([instance(mockRunner)]);
     container.ClearTests()
-    const testList2 = await container.LoadTests();
+    const testList2 = await container.LoadTests([instance(mockRunner)]);
     expect(JSON.stringify(testList1)).to.be.eq(JSON.stringify(testList2));
   })
 
   it("get the same id on consecutive loads", async () => {
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
-    const testList1 = await container.LoadTests();
-    const testList2 = await container.LoadTests();
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const testList1 = await container.LoadTests([instance(mockRunner)]);
+    const testList2 = await container.LoadTests([instance(mockRunner)]);
     expect(JSON.stringify(testList1)).to.be.eq(JSON.stringify(testList2));
   })
 
   it("run all tests", async () => {
     const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
 
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    await container.LoadTests();
+    await container.LoadTests([instance(mockRunner)]);
     await container.RunAllTests();
     verify(mockRunner.RunTest("Group1", "Test1")).called();
     verify(mockRunner.RunTest("Group2", "Test2")).called();
@@ -74,9 +74,9 @@ describe("CppUTestContainer should", () => {
   it("run test by id", async () => {
     const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
 
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     const testToRun = (allTests[0].children[0] as TestSuiteInfo).children[0];
     await container.RunTest(testToRun.id);
     verify(mockRunner.RunTest("Group1", "Test1")).called();
@@ -84,9 +84,9 @@ describe("CppUTestContainer should", () => {
   })
 
   it("run tests by ids", async () => {
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     const testsToRun = [
       (allTests[0].children[0] as TestSuiteInfo).children[0],
       (allTests[0].children[1] as TestSuiteInfo).children[0]
@@ -100,9 +100,9 @@ describe("CppUTestContainer should", () => {
     const mockRunner1 = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
     const mockRunner2 = createMockRunner("Exec2", "Group3.Test1 Group4.Test2");
 
-    const container = new CppUTestContainer([instance(mockRunner1), instance(mockRunner2)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner1), instance(mockRunner2)]);
     expect(allTests).to.have.lengthOf(2);
     const testsToRun = allTests[0];
     await container.RunTest(testsToRun.id);
@@ -114,9 +114,9 @@ describe("CppUTestContainer should", () => {
   it("run tests by group ids", async () => {
     const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group1.Test2 Group2.Test2 Group2.Test5");
 
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     expect(allTests).to.have.lengthOf(1);
     expect(allTests[0].children).to.have.lengthOf(2);
     const testsToRunId = allTests[0].children[0].id;
@@ -132,9 +132,9 @@ describe("CppUTestContainer should", () => {
     const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group1.Test2");
     when(mockRunner.RunTest(anyString(), anyString())).thenResolve("Success");
 
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     const testToRun = (allTests[0].children[0] as TestSuiteInfo).children[0];
     return expect(container.RunTest(testToRun.id)).to.be
       .eventually.fulfilled
@@ -150,9 +150,9 @@ describe("CppUTestContainer should", () => {
     reset(mockResultParser);
     when(mockResultParser.GetResult("Success")).thenReturn(new TestResult(TestState.Passed, ""));
     when(mockResultParser.GetResult("Failed")).thenReturn(new TestResult(TestState.Failed, "Failed"));
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     const testToRun = (allTests[0].children[0] as TestSuiteInfo);
     return expect(container.RunTest(testToRun.id)).to.be
       .eventually.fulfilled
@@ -172,9 +172,9 @@ describe("CppUTestContainer should", () => {
     when(mockSetting.GetWorkspaceFolders()).thenReturn([instance(mockFolder)]);
     when(mockSetting.GetDebugConfiguration()).thenReturn(debugConfigSpy);
     when(mockRunner.Command).thenReturn("myProgram");
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     expect(allTests).to.have.lengthOf(1);
     const testsToRunId = (allTests[0].children[0] as CppUTestGroup).children[0].id;
 
@@ -195,9 +195,9 @@ describe("CppUTestContainer should", () => {
     when(mockSetting.GetWorkspaceFolders()).thenReturn([instance(mockFolder)]);
     when(mockSetting.GetDebugConfiguration()).thenReturn(debugConfigSpy);
     when(mockRunner.Command).thenReturn("myProgram");
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     expect(allTests).to.have.lengthOf(1);
     const testsToRunId = allTests[0].children[0].id;
 
@@ -211,9 +211,9 @@ describe("CppUTestContainer should", () => {
   it("thrown an error if the debugger is started without config", async () => {
     mockSetting = mock<SettingsProvider>();
     when(mockSetting.GetDebugConfiguration()).thenReturn("");
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     const testsToRunId = allTests[0].id;
 
     return expect(container.DebugTest(testsToRunId)).to.be.
@@ -221,9 +221,9 @@ describe("CppUTestContainer should", () => {
   })
 
   it("thrown an error if the debugger is started without workspaceFolders", async () => {
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
-    const allTests = await container.LoadTests();
+    const allTests = await container.LoadTests([instance(mockRunner)]);
     const testsToRunId = allTests[0].id;
 
     return expect(container.DebugTest(testsToRunId)).to.be.
@@ -231,8 +231,8 @@ describe("CppUTestContainer should", () => {
   })
 
   it("notify the caller on test start and finish", async () => {
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
-    const allTests = await container.LoadTests();
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const allTests = await container.LoadTests([instance(mockRunner)]);
 
     const testToRun = (allTests[0].children[0] as TestSuiteInfo).children[0];
     let testOnStart = undefined;
@@ -248,7 +248,9 @@ describe("CppUTestContainer should", () => {
 
   it("kill the process currently running", async () => {
     const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
-    const container = new CppUTestContainer([instance(mockRunner)], instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+    
+    await container.LoadTests([instance(mockRunner)]);
 
     container.KillRunningProcesses();
     verify(mockRunner.KillProcess()).called();


### PR DESCRIPTION
Settings are automatically reloaded when the user changes them.

Additionally, test runners are refreshed when tests are reloaded, so new and deleted test executables are automatically detected.

Note: I've also cleaned up settings nomenclature for homogeneity with the extension name.