### PR TITLE
Add user setting to configure test location fetch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,18 @@
           "type": "string",
           "scope": "resource"
         },
+        "cpputestTestAdapter.testLocationFetchMode": {
+          "description": "",
+          "default": "auto",
+          "type": "string",
+          "enum": ["auto", "debug dump", "disabled"],
+          "enumDescriptions": [
+            "Selects the best fetch mode for the current architecture",
+            "Gets test location information from debug symbols in test executables",
+            "Test location fetch disabled"
+          ],
+          "scope": "resource"
+        },
         "cpputestTestAdapter.logpanel": {
           "description": "Write diagnostic logs to an output panel",
           "type": "boolean",

--- a/src/Domain/CppUTestContainer.ts
+++ b/src/Domain/CppUTestContainer.ts
@@ -6,7 +6,7 @@ import { CppUTest } from "./CppUTest";
 import { TestState } from "./TestState";
 import { ResultParser } from "./ResultParser";
 import ExecutableRunner from "../Infrastructure/ExecutableRunner";
-import { SettingsProvider } from "../Infrastructure/SettingsProvider";
+import { SettingsProvider, TestLocationFetchMode } from "../Infrastructure/SettingsProvider";
 import { VscodeAdapter } from "../Infrastructure/VscodeAdapter";
 
 export default class CppUTestContainer {
@@ -148,12 +148,14 @@ export default class CppUTestContainer {
   private async UpdateTestSuite(runner: ExecutableRunner, testString: string): Promise<CppUTestSuite> {
     const testSuite = this.GetTestSuite(runner.Name);
     testSuite.UpdateFromTestListString(testString);
-    for(const test of testSuite.Tests) {
-      try {
-        const debugString = await runner.GetDebugSymbols(test.group, test.label);
-        test.AddDebugInformation(debugString);
-      } catch (error) {
-        console.error(error);
+    if(this.settingsProvider.TestLocationFetchMode == TestLocationFetchMode.DebugDump) {
+      for(const test of testSuite.Tests) {
+        try {
+          const debugString = await runner.GetDebugSymbols(test.group, test.label);
+          test.AddDebugInformation(debugString);
+        } catch (error) {
+          console.error(error);
+        }
       }
     }
     return testSuite;

--- a/src/Infrastructure/SettingsProvider.ts
+++ b/src/Infrastructure/SettingsProvider.ts
@@ -1,8 +1,14 @@
 import { DebugConfiguration, WorkspaceFolder } from 'vscode';
 
+export enum TestLocationFetchMode {
+  DebugDump,
+  Disabled
+}
+
 export interface SettingsProvider {
   GetTestRunners(): string[];
   GetTestPath(): string;
+  get TestLocationFetchMode(): TestLocationFetchMode;
   GetDebugConfiguration(): (DebugConfiguration | string);
   GetWorkspaceFolders(): readonly WorkspaceFolder[] | undefined
 }

--- a/src/Infrastructure/VscodeSettingsProvider.ts
+++ b/src/Infrastructure/VscodeSettingsProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { glob } from 'glob';
-import { SettingsProvider } from './SettingsProvider';
+import { SettingsProvider, TestLocationFetchMode } from './SettingsProvider';
 
 export default class VscodeSettingsProvider implements SettingsProvider {
   private config: vscode.WorkspaceConfiguration;
@@ -27,6 +27,17 @@ export default class VscodeSettingsProvider implements SettingsProvider {
     return this.ResolveSettingsVariable(this.config.testExecutablePath);
   }
 
+  public get TestLocationFetchMode(): TestLocationFetchMode {
+    switch(this.config.testLocationFetchMode) {
+      case 'debug dump':
+        return TestLocationFetchMode.DebugDump;
+      case 'auto':
+        return (process.platform === "win32" ? TestLocationFetchMode.Disabled : TestLocationFetchMode.DebugDump);
+      case 'disabled':
+      default:
+        return TestLocationFetchMode.Disabled;
+    }
+  }
 
   public GetDebugConfiguration(): (vscode.DebugConfiguration | string) {
     // Thanks to: https://github.com/matepek/vscode-catch2-test-adapter/blob/9a2e9f5880ef3907d80ff99f3d6d028270923c95/src/Configurations.ts#L125


### PR DESCRIPTION
In windows test loading takes a lot of time because on the background the extension is trying to get the debug info from the test executables and the execution of external programs that it is invoking is failing. To avoid this a new configuration options is added to let the user disable test location fetch (which by default is disabled in windows).

Note: This PR is built on top of #28. To see the changes specific to this PR just peek on the last commit.