### PR TITLE
Query test location from test executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,10 @@
           "description": "",
           "default": "auto",
           "type": "string",
-          "enum": ["auto", "debug dump", "disabled"],
+          "enum": ["auto", "test query", "debug dump", "disabled"],
           "enumDescriptions": [
-            "Selects the best fetch mode for the current architecture",
+            "Selects the best fetch mode for the current operating system and CppUTest capabilities",
+            "Gets test location information by querying the test executables",
             "Gets test location information from debug symbols in test executables",
             "Test location fetch disabled"
           ],

--- a/src/Domain/CppUTestSuite.ts
+++ b/src/Domain/CppUTestSuite.ts
@@ -6,19 +6,46 @@ export default class CppUTestSuite extends CppUTestGroup {
     super(label, label);
   }
 
-  public UpdateFromTestListString(testListString: string): void {
+  public UpdateFromTestListString(testListString: string, hasLocation: boolean): void {
+    if (hasLocation) {
+      this.UpdateFromTestListStringWithLocation(testListString);
+    } else {
+      this.UpdateFromTestListStringWithoutLocation(testListString);
+    }
+  }
+
+  private UpdateFromTestListStringWithoutLocation(testListString: string): void {
     const groupAndGroupStrings: string[] = testListString.split(" ");
     this.children.splice(0, this.children.length);
     groupAndGroupStrings
       .map(gs => gs.split("."))
-      .map(split => this.UpdateGroupAndTest(split[0], split[1]));
+      .map(split => this.UpdateGroupAndTest(split[0], split[1], undefined, undefined));
   }
 
-  private UpdateGroupAndTest(groupName: string, testName: string): void {
+  private UpdateFromTestListStringWithLocation(testListString: string): void {
+    const groupAndGroupStrings: string[] = testListString.split("\n").filter(gs => (gs.length > 0));
+    this.children.splice(0, this.children.length);
+    groupAndGroupStrings
+      .map(gs => this.ParseTestInfo(gs))
+      .map(split => this.UpdateGroupAndTest(split[0], split[1], split[2], split[3]));
+  }
+
+  private UpdateGroupAndTest(groupName: string, testName: string, file: string | undefined, line: string | undefined): void {
     let testGroup = this.children.find(c => c.label === groupName) as CppUTestGroup;
     if (!testGroup) {
       testGroup = this.AddTestGroup(groupName);
     }
-    testGroup.AddTest(testName);
+    testGroup.AddTest(testName, file, line ? parseInt(line) : undefined);
+  }
+
+  private ParseTestInfo(testInfo: string): string[] {
+    const firstSeparatorIndex = testInfo.indexOf(".");
+    const secondSeparatorIndex = testInfo.indexOf(".", firstSeparatorIndex + 1);
+    const lastSeparatorIndex = testInfo.lastIndexOf(".");
+    const groupName = testInfo.substring(0, firstSeparatorIndex);
+    const testName = testInfo.substring(firstSeparatorIndex + 1, secondSeparatorIndex);
+    const file = testInfo.substring(secondSeparatorIndex + 1, lastSeparatorIndex);
+    const line = testInfo.substring(lastSeparatorIndex + 1);
+    return [groupName, testName, file, line];
   }
 }

--- a/src/Infrastructure/SettingsProvider.ts
+++ b/src/Infrastructure/SettingsProvider.ts
@@ -1,6 +1,8 @@
 import { DebugConfiguration, WorkspaceFolder } from 'vscode';
 
 export enum TestLocationFetchMode {
+  Auto,
+  TestQuery,
   DebugDump,
   Disabled
 }

--- a/src/Infrastructure/VscodeSettingsProvider.ts
+++ b/src/Infrastructure/VscodeSettingsProvider.ts
@@ -29,10 +29,12 @@ export default class VscodeSettingsProvider implements SettingsProvider {
 
   public get TestLocationFetchMode(): TestLocationFetchMode {
     switch(this.config.testLocationFetchMode) {
+      case 'test query':
+        return TestLocationFetchMode.TestQuery;
       case 'debug dump':
         return TestLocationFetchMode.DebugDump;
       case 'auto':
-        return (process.platform === "win32" ? TestLocationFetchMode.Disabled : TestLocationFetchMode.DebugDump);
+        return TestLocationFetchMode.Auto;
       case 'disabled':
       default:
         return TestLocationFetchMode.Disabled;

--- a/tests/CppUTestContainer.spec.ts
+++ b/tests/CppUTestContainer.spec.ts
@@ -5,7 +5,7 @@ import CppUTestContainer from "../src/Domain/CppUTestContainer";
 import { CppUTestGroup } from "../src/Domain/CppUTestGroup";
 import { TestSuiteInfo } from "vscode-test-adapter-api";
 import { TestResult } from "../src/Domain/TestResult";
-import { SettingsProvider } from "../src/Infrastructure/SettingsProvider";
+import { SettingsProvider, TestLocationFetchMode } from "../src/Infrastructure/SettingsProvider";
 import { VscodeAdapter } from "../src/Infrastructure/VscodeAdapter";
 import { DebugConfiguration, WorkspaceFolder } from "vscode";
 import { TestState } from "../src/Domain/TestState";
@@ -18,31 +18,114 @@ describe("CppUTestContainer should", () => {
   let mockResultParser: ResultParser;
 
   beforeEach(() => {
-    mockRunner = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
+    mockRunner = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group2.Test2", false);
     mockSetting = mock<SettingsProvider>();
     mockAdapter = mock<VscodeAdapter>();
     mockResultParser = mock<ResultParser>();
     when(mockSetting.GetTestPath()).thenReturn("/test/myPath");
     when(mockSetting.GetTestRunners()).thenReturn(["/test/myPath/Exec1"]);
+    when(mockSetting.TestLocationFetchMode).thenReturn(TestLocationFetchMode.Disabled);
     when(mockResultParser.GetResult(anything())).thenReturn(new TestResult(TestState.Passed, ""));
   })
 
-  it("load all tests from all testrunners", async () => {
-    const mockRunner1 = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
-    const mockRunner2 = createMockRunner("Exec2", "Group4.Test1 Group5.Test2 Group5.Test42");
+  it("load all tests from all testrunners without location info", async () => {
+    const mockRunner1 = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group2.Test2", false);
+    const mockRunner2 = createMockRunner("Exec2", TestLocationFetchMode.Disabled, "Group4.Test1 Group5.Test2 Group5.Test42", false);
+    const mockSetting = mock<SettingsProvider>();
+    when(mockSetting.TestLocationFetchMode).thenReturn(TestLocationFetchMode.Disabled);
 
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
     const allTests = await container.LoadTests([instance(mockRunner1), instance(mockRunner2)]);
     expect(allTests).to.be.lengthOf(2);
+
     expect(allTests[0].label).to.be.eq("Exec1");
-    expect(allTests[1].label).to.be.eq("Exec2");
+    expect(allTests[0].children).to.be.lengthOf(2);
     expect(allTests[0].children[0].label).to.be.eq("Group1");
     expect(allTests[0].children[0].type).to.be.eq("suite");
+    expect((allTests[0].children[0] as CppUTestGroup).children).to.be.lengthOf(1);
     expect((allTests[0].children[0] as CppUTestGroup).children[0].label).to.be.eq("Test1");
+    expect((allTests[0].children[0] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[0].children[0] as CppUTestGroup).children[0].file).to.be.eq(undefined);
+    expect((allTests[0].children[0] as CppUTestGroup).children[0].line).to.be.eq(undefined);
+    expect(allTests[0].children[1].label).to.be.eq("Group2");
+    expect(allTests[0].children[1].type).to.be.eq("suite");
+    expect((allTests[0].children[1] as CppUTestGroup).children).to.be.lengthOf(1);
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].label).to.be.eq("Test2");
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].file).to.be.eq(undefined);
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].line).to.be.eq(undefined);
 
     expect(allTests[1].label).to.be.eq("Exec2");
+    expect(allTests[1].children).to.be.lengthOf(2);
+    expect(allTests[1].children[0].label).to.be.eq("Group4");
+    expect(allTests[1].children[0].type).to.be.eq("suite");
+    expect((allTests[1].children[0] as CppUTestGroup).children).to.be.lengthOf(1);
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].label).to.be.eq("Test1");
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].file).to.be.eq(undefined);
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].line).to.be.eq(undefined);
+    expect(allTests[1].children[1].label).to.be.eq("Group5");
+    expect(allTests[1].children[1].type).to.be.eq("suite");
+    expect((allTests[1].children[1] as CppUTestGroup).children).to.be.lengthOf(2);
     expect((allTests[1].children[1] as CppUTestGroup).children[0].label).to.be.eq("Test42");
+    expect((allTests[1].children[1] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[1].children[1] as CppUTestGroup).children[0].file).to.be.eq(undefined);
+    expect((allTests[1].children[1] as CppUTestGroup).children[0].line).to.be.eq(undefined);
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].label).to.be.eq("Test2");
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].type).to.be.eq("test");
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].file).to.be.eq(undefined);
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].line).to.be.eq(undefined);
+  })
+
+  it("load all tests from all testrunners with location info", async () => {
+    const mockRunner1 = createMockRunner("Exec1", TestLocationFetchMode.TestQuery, "Group1.Test1.Test.file.name.cpp.12\nGroup2.Test2.Test2.cpp.4356\n", true);
+    const mockRunner2 = createMockRunner("Exec2", TestLocationFetchMode.TestQuery, "Group4.Test1.File4.75\nGroup5.Test2.File5.342\nGroup5.Test42.File5.4", true);
+    const mockSetting = mock<SettingsProvider>();
+    when(mockSetting.TestLocationFetchMode).thenReturn(TestLocationFetchMode.TestQuery);
+
+    const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
+
+    const allTests = await container.LoadTests([instance(mockRunner1), instance(mockRunner2)]);
+    expect(allTests).to.be.lengthOf(2);
+
+    expect(allTests[0].label).to.be.eq("Exec1");
+    expect(allTests[0].children).to.be.lengthOf(2);
+    expect(allTests[0].children[0].label).to.be.eq("Group1");
+    expect(allTests[0].children[0].type).to.be.eq("suite");
+    expect((allTests[0].children[0] as CppUTestGroup).children).to.be.lengthOf(1);
+    expect((allTests[0].children[0] as CppUTestGroup).children[0].label).to.be.eq("Test1");
+    expect((allTests[0].children[0] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[0].children[0] as CppUTestGroup).children[0].file).to.be.eq("Test.file.name.cpp");
+    expect((allTests[0].children[0] as CppUTestGroup).children[0].line).to.be.eq(12);
+    expect(allTests[0].children[1].label).to.be.eq("Group2");
+    expect(allTests[0].children[1].type).to.be.eq("suite");
+    expect((allTests[0].children[1] as CppUTestGroup).children).to.be.lengthOf(1);
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].label).to.be.eq("Test2");
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].file).to.be.eq("Test2.cpp");
+    expect((allTests[0].children[1] as CppUTestGroup).children[0].line).to.be.eq(4356);
+
+    expect(allTests[1].label).to.be.eq("Exec2");
+    expect(allTests[1].children).to.be.lengthOf(2);
+    expect(allTests[1].children[0].label).to.be.eq("Group4");
+    expect(allTests[1].children[0].type).to.be.eq("suite");
+    expect((allTests[1].children[0] as CppUTestGroup).children).to.be.lengthOf(1);
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].label).to.be.eq("Test1");
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].file).to.be.eq("File4");
+    expect((allTests[1].children[0] as CppUTestGroup).children[0].line).to.be.eq(75);
+    expect(allTests[1].children[1].label).to.be.eq("Group5");
+    expect(allTests[1].children[1].type).to.be.eq("suite");
+    expect((allTests[1].children[1] as CppUTestGroup).children).to.be.lengthOf(2);
+    expect((allTests[1].children[1] as CppUTestGroup).children[0].label).to.be.eq("Test42");
+    expect((allTests[1].children[1] as CppUTestGroup).children[0].type).to.be.eq("test");
+    expect((allTests[1].children[1] as CppUTestGroup).children[0].file).to.be.eq("File5");
+    expect((allTests[1].children[1] as CppUTestGroup).children[0].line).to.be.eq(4);
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].label).to.be.eq("Test2");
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].type).to.be.eq("test");
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].file).to.be.eq("File5");
+    expect((allTests[1].children[1] as CppUTestGroup).children[1].line).to.be.eq(342);
   })
 
   it("reload all tests after clear", async () => {
@@ -61,7 +144,8 @@ describe("CppUTestContainer should", () => {
   })
 
   it("run all tests", async () => {
-    const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
+    const mockRunner = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group2.Test2", false);
+    when(mockSetting.TestLocationFetchMode).thenReturn(TestLocationFetchMode.Disabled);
 
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
@@ -72,7 +156,7 @@ describe("CppUTestContainer should", () => {
   })
 
   it("run test by id", async () => {
-    const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
+    const mockRunner = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group2.Test2", false);
 
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
@@ -97,8 +181,8 @@ describe("CppUTestContainer should", () => {
   })
 
   it("run tests by executable group id", async () => {
-    const mockRunner1 = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
-    const mockRunner2 = createMockRunner("Exec2", "Group3.Test1 Group4.Test2");
+    const mockRunner1 = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group2.Test2", false);
+    const mockRunner2 = createMockRunner("Exec2", TestLocationFetchMode.Disabled, "Group3.Test1 Group4.Test2", false);
 
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
@@ -112,7 +196,7 @@ describe("CppUTestContainer should", () => {
   })
 
   it("run tests by group ids", async () => {
-    const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group1.Test2 Group2.Test2 Group2.Test5");
+    const mockRunner = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group1.Test2 Group2.Test2 Group2.Test5", false);
 
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
@@ -129,7 +213,7 @@ describe("CppUTestContainer should", () => {
   })
 
   it("return a TestResult after sucessful run", async () => {
-    const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group1.Test2");
+    const mockRunner = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group1.Test2", false);
     when(mockRunner.RunTest(anyString(), anyString())).thenResolve("Success");
 
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
@@ -144,7 +228,7 @@ describe("CppUTestContainer should", () => {
   })
 
   it("return a TestResult after failed run", async () => {
-    const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group1.Test2");
+    const mockRunner = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group1.Test2", false);
     when(mockRunner.RunTest("Group1", "Test1")).thenResolve("Success");
     when(mockRunner.RunTest("Group1", "Test2")).thenResolve("Failed");
     reset(mockResultParser);
@@ -211,6 +295,7 @@ describe("CppUTestContainer should", () => {
   it("thrown an error if the debugger is started without config", async () => {
     mockSetting = mock<SettingsProvider>();
     when(mockSetting.GetDebugConfiguration()).thenReturn("");
+    when(mockSetting.TestLocationFetchMode).thenReturn(TestLocationFetchMode.Disabled);
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
 
     const allTests = await container.LoadTests([instance(mockRunner)]);
@@ -247,7 +332,7 @@ describe("CppUTestContainer should", () => {
   })
 
   it("kill the process currently running", async () => {
-    const mockRunner = createMockRunner("Exec1", "Group1.Test1 Group2.Test2");
+    const mockRunner = createMockRunner("Exec1", TestLocationFetchMode.Disabled, "Group1.Test1 Group2.Test2", false);
     const container = new CppUTestContainer(instance(mockSetting), instance(mockAdapter), instance(mockResultParser));
     
     await container.LoadTests([instance(mockRunner)]);
@@ -257,9 +342,9 @@ describe("CppUTestContainer should", () => {
   })
 });
 
-function createMockRunner(runnerName: string, testListString: string) {
+function createMockRunner(runnerName: string, fetchMode: TestLocationFetchMode, testListString: string, hasLocation: boolean) {
   const mockRunner = mock<ExecutableRunner>();
   when(mockRunner.Name).thenReturn(runnerName);
-  when(mockRunner.GetTestList()).thenResolve(testListString);
+  when(mockRunner.GetTestList(fetchMode)).thenResolve([testListString, hasLocation]);
   return mockRunner;
 }

--- a/tests/CppUTestSuite.spec.ts
+++ b/tests/CppUTestSuite.spec.ts
@@ -5,13 +5,43 @@ import CppUTestSuite from '../src/Domain/CppUTestSuite';
 describe('CppUTestSuite should', () => {
   const suite = new CppUTestSuite("Label");
 
-  it('create a TestSuite from an test list string', () => {
+  it('create a TestSuite from an test list string without location', () => {
     const testListString = "Group1.Test1 Group1.Test2 Group2.Test1";
-    suite.UpdateFromTestListString(testListString);
+    suite.UpdateFromTestListString(testListString, false);
     expect(suite.label).to.be.equal("Label");
     expect(suite.children.length).to.be.eq(2);
     expect(suite.children[0].label).to.be.equal("Group1");
     expect(suite.children[1].label).to.be.equal("Group2");
+    expect((suite.children[0] as CppUTestGroup).children.length).to.be.equal(2);
     expect((suite.children[0] as CppUTestGroup).children[0].label).to.be.equal("Test2");
+    expect((suite.children[0] as CppUTestGroup).children[0].file).to.be.equal(undefined);
+    expect((suite.children[0] as CppUTestGroup).children[0].line).to.be.equal(undefined);
+    expect((suite.children[0] as CppUTestGroup).children[1].label).to.be.equal("Test1");
+    expect((suite.children[0] as CppUTestGroup).children[1].file).to.be.equal(undefined);
+    expect((suite.children[0] as CppUTestGroup).children[1].line).to.be.equal(undefined);
+    expect((suite.children[1] as CppUTestGroup).children.length).to.be.equal(1);
+    expect((suite.children[1] as CppUTestGroup).children[0].label).to.be.equal("Test1");
+    expect((suite.children[1] as CppUTestGroup).children[0].file).to.be.equal(undefined);
+    expect((suite.children[1] as CppUTestGroup).children[0].line).to.be.equal(undefined);
+  });
+
+  it('create a TestSuite from an test list string with location', () => {
+    const testListString = "Group1.Test1.C:\\File\Name.cpp.345\nGroup1.Test2./path/to.test.file.9873\nGroup2.Test1.Unknown.9889877\n";
+    suite.UpdateFromTestListString(testListString, true);
+    expect(suite.label).to.be.equal("Label");
+    expect(suite.children.length).to.be.eq(2);
+    expect(suite.children[0].label).to.be.equal("Group1");
+    expect(suite.children[1].label).to.be.equal("Group2");
+    expect((suite.children[0] as CppUTestGroup).children.length).to.be.equal(2);
+    expect((suite.children[0] as CppUTestGroup).children[0].label).to.be.equal("Test2");
+    expect((suite.children[0] as CppUTestGroup).children[0].file).to.be.equal("/path/to.test.file");
+    expect((suite.children[0] as CppUTestGroup).children[0].line).to.be.equal(9873);
+    expect((suite.children[0] as CppUTestGroup).children[1].label).to.be.equal("Test1");
+    expect((suite.children[0] as CppUTestGroup).children[1].file).to.be.equal("C:\\File\Name.cpp");
+    expect((suite.children[0] as CppUTestGroup).children[1].line).to.be.equal(345);
+    expect((suite.children[1] as CppUTestGroup).children.length).to.be.equal(1);
+    expect((suite.children[1] as CppUTestGroup).children[0].label).to.be.equal("Test1");
+    expect((suite.children[1] as CppUTestGroup).children[0].file).to.be.equal("Unknown");
+    expect((suite.children[1] as CppUTestGroup).children[0].line).to.be.equal(9889877);
   });
 });

--- a/tests/ExecutableRunner.spec.ts
+++ b/tests/ExecutableRunner.spec.ts
@@ -3,17 +3,20 @@ import * as chaiAsPromised from "chai-as-promised";
 import ExecutableRunner from '../src/Infrastructure/ExecutableRunner';
 import { ProcessExecuter } from '../src/Application/ProcessExecuter';
 import { anything, instance, mock, verify, when } from "ts-mockito";
+import { TestLocationFetchMode } from '../src/Infrastructure/SettingsProvider';
 
 chaiUse(chaiAsPromised);
 
 const outputStrings = [
   {
     name: "short",
-    value: "Group1.Test1 Group2.Test2"
+    value: "Group1.Test1.File.Name1.cpp.789\nGroup2.File_name_2.874",
+    hasLocation: true
   },
   {
     name: "long",
-    value: "Group1.Test1 Group2.Test2 Group2.Test3 Group2.Test4"
+    value: "Group1.Test1 Group2.Test2 Group2.Test3 Group2.Test4",
+    hasLocation: false
   }
 ]
 
@@ -45,9 +48,10 @@ describe("ExecutableRunner should", () => {
 
       let runner = new ExecutableRunner(processExecuter, command);
 
-      let testListString = await runner.GetTestList();
+      let testList = await runner.GetTestList(testOutput.hasLocation ? TestLocationFetchMode.TestQuery : TestLocationFetchMode.Disabled);
 
-      expect(testListString).to.be.eq(testOutput.value);
+      expect(testList[0]).to.be.eq(testOutput.value);
+      expect(testList[1]).to.be.eq(testOutput.hasLocation);
     })
   })
 
@@ -56,7 +60,7 @@ describe("ExecutableRunner should", () => {
     const command = "runnable";
 
     let runner = new ExecutableRunner(processExecuter, command);
-    return expect(runner.GetTestList()).to.be.eventually.
+    return expect(runner.GetTestList(TestLocationFetchMode.Auto)).to.be.eventually.
       be.rejectedWith("whoops")
       .and.be.an.instanceOf(Error)
   })
@@ -90,7 +94,7 @@ describe("ExecutableRunner should", () => {
     });
 
     let runner = new ExecutableRunner(instance(processExecuter), command, "/tmp/myPath");
-    await runner.GetTestList();
+    await runner.GetTestList(TestLocationFetchMode.Auto);
     expect(calledOptions.cwd).to.be.eq("/tmp/myPath");
   })
 


### PR DESCRIPTION
This PR implements getting the test location info by querying the test executable using the option "-ll" as commented in #24, which should work seamlessly in all platforms.

Since this CppUTest option is fairly new and has not been published yet in any CppUTest official release, I've made it coexist with the current method of fetching debug info from the executable using external tools.

In the fetch mode default setting (auto) the extension will try to use the new option to get test info, falling back to the standard option "-ln" if it is not supported by the user's CppUTest version.

Note: This PR is build on top of #29, so you can if you want just merge this PR and close the other, or merge both.