### PR TITLE
Display location of failure when a test fails

### DIFF
--- a/src/Domain/CppUTestContainer.ts
+++ b/src/Domain/CppUTestContainer.ts
@@ -53,8 +53,8 @@ export default class CppUTestContainer {
         for (const test of (testGroup as CppUTestGroup).children) {
           const runner = this.runners.filter(r => r.Name === executableGroup.label)[0];
           this.onTestStartHandler((test as CppUTest));
-          const resultString = await runner.RunTest(testGroup.label, test.label);
-          const testResult = this.resultParser.GetResult(resultString);
+          const runResult = await runner.RunTest(testGroup.label, test.label);
+          const testResult = this.resultParser.GetResult(runResult);
           this.onTestFinishHandler((test as CppUTest), testResult);
           testResults.push(testResult);
         }
@@ -80,8 +80,8 @@ export default class CppUTestContainer {
         if (test && runner) {
           this.onTestStartHandler(test);
           try {
-            const resultString = await runner.RunTest(test.group, test.label);
-            const testResult = this.resultParser.GetResult(resultString);
+            const runResult = await runner.RunTest(test.group, test.label);
+            const testResult = this.resultParser.GetResult(runResult);
             this.onTestFinishHandler(test, testResult);
             testResults.push(testResult);
           } catch (error) {

--- a/src/Domain/RegexResultParser.ts
+++ b/src/Domain/RegexResultParser.ts
@@ -21,11 +21,12 @@ export class RegexResultParser implements ResultParser {
       }
       if (line.includes("Failure in")) {
         state = TestState.Failed;
+        message = message.concat(line, "\n");
         continue;
       }
       if (state === TestState.Failed) {
         if (line.trimRight() !== "") {
-          message = message.concat(line.trim(), "\n");
+          message = message.concat(line, "\n");
         } else {
           return new TestResult(state, message.trim());
         }

--- a/src/Domain/RegexResultParser.ts
+++ b/src/Domain/RegexResultParser.ts
@@ -1,38 +1,63 @@
 import { TestResult } from "./TestResult";
 import { TestState } from "./TestState";
 import { ResultParser } from "./ResultParser";
+import { RunResult, RunResultStatus } from "../Infrastructure/ExecutableRunner";
 
 export class RegexResultParser implements ResultParser {
 
-  public GetResult(resultString: string): TestResult {
-    const lines = resultString.split("\n");
+  public GetResult(resultOutput: RunResult): TestResult {
+    switch (resultOutput.Status) {
+      case RunResultStatus.Success:
+        return this.ParseResultSuccess(resultOutput.Text);
+      case RunResultStatus.Failure:
+        return this.ParseResultFailure(resultOutput.Text);
+      case RunResultStatus.Error:
+        return new TestResult(TestState.Failed, resultOutput.Text.trimRight());
+    }
+  }
+
+  private ParseResultSuccess(resultText: string): TestResult {
+    const lines = resultText.split("\n");
+    const regexPattern: RegExp = /(\w*)_*TEST\((\w*), (\w*)\)/;
+    const match = regexPattern.exec(lines[0]);
+    if (match !== null) {
+      if (match[1] == "IGNORE_") {
+        return new TestResult(TestState.Skipped, "");
+      } else {
+        return new TestResult(TestState.Passed, "");
+      }
+    } else {
+      const message = lines.slice(1).join("\n");
+      return new TestResult(TestState.Unknown, message.trimRight());
+    }
+  }
+
+  private ParseResultFailure(resultText: string): TestResult {
+    const lines = resultText.split("\n");
     let state: TestState = TestState.Unknown;
     let message = "";
-    for (const line of lines) {
-      const regexPattern: RegExp = /(\w*)_*TEST\((\w*), (\w*)\)/;
-      const match = regexPattern.exec(line);
-      if (match !== null) {
-        if (match[1] == "IGNORE_") {
-          state = TestState.Skipped;
-          return new TestResult(state, "");
-        } else {
-          state = TestState.Passed;
-        }
-      }
+    const regexPatternHeading: RegExp = /(\w*)_*TEST\((\w*), (\w*)\)/;
+    const match = regexPatternHeading.exec(lines[0]);
+    if (match === null) {
+      const message = lines.slice(1).join("\n");
+      return new TestResult(TestState.Unknown, message.trimRight());
+    }
+    const regexPatternTail: RegExp = /^\s*-\s\d+\sms\s*$/;
+    for (const line of lines.slice(1)) {
       if (line.includes("Failure in")) {
         state = TestState.Failed;
         message = message.concat(line, "\n");
         continue;
       }
       if (state === TestState.Failed) {
-        if (line.trimRight() !== "") {
+        const match = regexPatternTail.exec(line);
+        if (match === null) {
           message = message.concat(line, "\n");
         } else {
-          return new TestResult(state, message.trim());
+          return new TestResult(state, message.trimRight());
         }
       }
-
     }
-    return new TestResult(state, message);
+    return new TestResult(state, message.trimRight());
   }
 }

--- a/src/Domain/ResultParser.ts
+++ b/src/Domain/ResultParser.ts
@@ -1,5 +1,6 @@
+import { RunResult } from "../Infrastructure/ExecutableRunner";
 import { TestResult } from "./TestResult";
 
 export interface ResultParser {
-  GetResult(resultString: string): TestResult;
+  GetResult(testOutput: RunResult): TestResult;
 }

--- a/tests/RegexResultParser.spec.ts
+++ b/tests/RegexResultParser.spec.ts
@@ -5,37 +5,42 @@ import { readFileSync } from "fs";
 import { RegexResultParser } from "../src/Domain/RegexResultParser";
 import { TestResult } from "../src/Domain/TestResult";
 import { TestState } from "../src/Domain/TestState";
+import { RunResultStatus, RunResult } from "../src/Infrastructure/ExecutableRunner";
 
-const allTests: { name: string, value: string[], expected: string[] }[] = JSON.parse(readFileSync("tests/testResults.json").toString());
+const allTests: { name: string, status: string, value: string[], expected: string[] }[] = 
+  JSON.parse(readFileSync("tests/testResults.json").toString());
 
 describe("RegexResultParser should", () => {
-  allTests.filter(t => t.name.startsWith("failing")).forEach(failingTest => {
-    it(`return failed result for '${failingTest.name}''`, () => {
+  allTests.filter(t => t.name.startsWith("failing")).forEach(test => {
+    it(`return failed result for '${test.name}''`, () => {
       const resultParser = new RegexResultParser();
 
-      const expectedTestResult = new TestResult(TestState.Failed, failingTest.expected.join("\n"));
-      const stringFromRunner = failingTest.value.join("\n");
-      expect(resultParser.GetResult(stringFromRunner)).to.be.deep.eq(expectedTestResult);
+      const expectedTestResult = new TestResult(TestState.Failed, test.expected.join("\n"));
+      const statusFromRunner : RunResultStatus = (<any>RunResultStatus)[test.status];
+      const stringFromRunner = test.value.join("\n");
+      expect(resultParser.GetResult(new RunResult(statusFromRunner, stringFromRunner))).to.be.deep.eq(expectedTestResult);
     })
   })
 
-  allTests.filter(t => t.name.startsWith("passing")).forEach(failingTest => {
-    it(`return passing result for '${failingTest.name}''`, () => {
+  allTests.filter(t => t.name.startsWith("passing")).forEach(test => {
+    it(`return passing result for '${test.name}''`, () => {
       const resultParser = new RegexResultParser();
 
-      const expectedTestResult = new TestResult(TestState.Passed, failingTest.expected.join("\n"));
-      const stringFromRunner = failingTest.value.join("\n");
-      expect(resultParser.GetResult(stringFromRunner)).to.be.deep.eq(expectedTestResult);
+      const expectedTestResult = new TestResult(TestState.Passed, test.expected.join("\n"));
+      const statusFromRunner : RunResultStatus = (<any>RunResultStatus)[test.status];
+      const stringFromRunner = test.value.join("\n");
+      expect(resultParser.GetResult(new RunResult(statusFromRunner, stringFromRunner))).to.be.deep.eq(expectedTestResult);
     })
   })
 
-  allTests.filter(t => t.name.startsWith("ignored")).forEach(failingTest => {
-    it(`return skipped result for '${failingTest.name}''`, () => {
+  allTests.filter(t => t.name.startsWith("ignored")).forEach(test => {
+    it(`return skipped result for '${test.name}''`, () => {
       const resultParser = new RegexResultParser();
 
-      const expectedTestResult = new TestResult(TestState.Skipped, failingTest.expected.join("\n"));
-      const stringFromRunner = failingTest.value.join("\n");
-      expect(resultParser.GetResult(stringFromRunner)).to.be.deep.eq(expectedTestResult);
+      const expectedTestResult = new TestResult(TestState.Skipped, test.expected.join("\n"));
+      const statusFromRunner : RunResultStatus = (<any>RunResultStatus)[test.status];
+      const stringFromRunner = test.value.join("\n");
+      expect(resultParser.GetResult(new RunResult(statusFromRunner, stringFromRunner))).to.be.deep.eq(expectedTestResult);
     })
   })
 });

--- a/tests/testResults.json
+++ b/tests/testResults.json
@@ -1,13 +1,14 @@
 [
         {
                 "name": "failingTest1",
+                "status": "Failure",
                 "value": [
                         "TEST(ClassName, Create)",
                         "C:\\Users\\tests\\basicTests.cpp(58): error: Failure in TEST(ClassName, Create)",
                         "        Message: This is failing",
                         "        CHECK(false) failed",
-                        "",
-                        "- 0 ms"
+                        " ",
+                        " - 0 ms"
                 ],
                 "expected": [
                         "C:\\Users\\tests\\basicTests.cpp(58): error: Failure in TEST(ClassName, Create)",
@@ -17,10 +18,12 @@
         },
         {
                 "name": "failingTest2",
+                "status": "Failure",
                 "value": [
                         "TEST(ClassName, Create)",
                         "/tests/basicTests.cpp(43): error: Failure in TEST(SecondClass, ShouldFail)",
                         "Message: This is also failing",
+                        "",
                         "CHECK(false) failed",
                         "",
                         "- 0 ms"
@@ -28,11 +31,13 @@
                 "expected": [
                         "/tests/basicTests.cpp(43): error: Failure in TEST(SecondClass, ShouldFail)",
                         "Message: This is also failing",
+                        "",
                         "CHECK(false) failed"
                 ]
         },
         {
                 "name": "failingTest3",
+                "status": "Failure",
                 "value": [
                         "TEST(TEST_GROUP1, TEST1)Memutil uses static memory",
                         "Memutil heap size = 0x4000000 (67108864 bytes)",
@@ -42,9 +47,9 @@
                         "expected <0>",
                         "but was <-2>",
                         "difference starts at position 0 at: < -2 >",
-                        "^",
+                        "                                       ^",
                         "",
-                        "25 ms",
+                        "- 25 ms",
                         "Errors (1 failures, 1283 tests, 1 ran, 79 checks, 0 ignored, 1282 filtered out, 25 ms)"
                 ],
                 "expected":[
@@ -52,11 +57,24 @@
                         "expected <0>",
                         "but was <-2>",
                         "difference starts at position 0 at: < -2 >",
-                        "^"
+                        "                                       ^"
+                ]
+        },
+        {
+                "name": "failingTest4",
+                "status": "Error",
+                "value": [
+                        "terminate called after throwing an instance of 'std::runtime_error'",
+                        "  what():  Invalid parameter value."
+                ],
+                "expected": [
+                        "terminate called after throwing an instance of 'std::runtime_error'",
+                        "  what():  Invalid parameter value."
                 ]
         },
         {
                 "name": "passingTest1",
+                "status": "Success",
                 "value": [
                         "TEST(ClassName, ShouldPass) - 0 ms"
                 ],
@@ -64,6 +82,7 @@
         },
         {
                 "name": "passingTest2",
+                "status": "Success",
                 "value":[
                         "TEST(TEST_GROUP1, ouptpuTEST1)Memutil uses static memory",
                         "Memutil heap size = 0x4000000 (67108864 bytes)",
@@ -76,6 +95,7 @@
         },
         {
                 "name": "ignoredTest1",
+                "status": "Success",
                 "value": [
                         "IGNORE_TEST(SecondClass, ShouldBeIgnored) - 0 ms"
                 ],
@@ -83,6 +103,7 @@
         },
         {
                 "name":"ignoredTest2",
+                "status": "Success",
                 "value":[
                         "IGNORE_TEST(TEST_GROUP1, TEST1) - 0 ms",
                         "",

--- a/tests/testResults.json
+++ b/tests/testResults.json
@@ -10,8 +10,9 @@
                         "- 0 ms"
                 ],
                 "expected": [
-                        "Message: This is failing",
-                        "CHECK(false) failed"
+                        "C:\\Users\\tests\\basicTests.cpp(58): error: Failure in TEST(ClassName, Create)",
+                        "        Message: This is failing",
+                        "        CHECK(false) failed"
                 ]
         },
         {
@@ -25,6 +26,7 @@
                         "- 0 ms"
                 ],
                 "expected": [
+                        "/tests/basicTests.cpp(43): error: Failure in TEST(SecondClass, ShouldFail)",
                         "Message: This is also failing",
                         "CHECK(false) failed"
                 ]
@@ -46,6 +48,7 @@
                         "Errors (1 failures, 1283 tests, 1 ran, 79 checks, 0 ignored, 1282 filtered out, 25 ms)"
                 ],
                 "expected":[
+                        "src/tests/omss_unit_tests/src/ut/ut_real/inventory_manager/TEST_GROUP1.cpp:51: error: Failure in TEST(TEST_GROUP1, TEST1)",
                         "expected <0>",
                         "but was <-2>",
                         "difference starts at position 0 at: < -2 >",


### PR DESCRIPTION
...and last but not least, this PR fixes #23.

I've also removed whitespace trimming on subsequent lines because CppUTest for some string check failures reports the position of the mismatching character using a '^' character aligned using spaces to the left. Now the displayed error is exactly as if viewed on a terminal.