### PR TITLE
Add config setting to chooe the debug launch profile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/package.json
+++ b/package.json
@@ -104,6 +104,12 @@
           "description": "Write diagnostic logs to the given file",
           "type": "string",
           "scope": "resource"
+        },
+        "cpputestTestAdapter.debugLaunchConfigurationName": {
+          "description": "The name of the configuration object from the launch.json file to use for debugging tests. Defaults to the first profile",
+          "default": "",
+          "type": "string",
+          "scope": "resource"
         }
       }
     }

--- a/src/Infrastructure/VscodeSettingsProvider.ts
+++ b/src/Infrastructure/VscodeSettingsProvider.ts
@@ -49,7 +49,25 @@ export default class VscodeSettingsProvider implements SettingsProvider {
     const wpLaunchConfigs: string | undefined = vscode.workspace
       .getConfiguration('launch', vscode.workspace.workspaceFolders[0].uri)
       .get<string>('configurations');
+
+    const hasConfiguredLaunchProfiles: boolean = this.config.debugLaunchProfileName;
+
+    
     if (wpLaunchConfigs && Array.isArray(wpLaunchConfigs) && wpLaunchConfigs.length > 0) {
+      if(hasConfiguredLaunchProfiles) {
+        // try and match the config by name
+        for (let i = 0; i < wpLaunchConfigs.length; ++i) {
+          if (wpLaunchConfigs[i].name == this.config.debugLaunchConfigurationName) {
+            const debugConfig: vscode.DebugConfiguration = Object.assign({}, wpLaunchConfigs[i], {
+              program: "",
+              target: ""
+            });
+            return debugConfig;
+          }
+        }
+      } 
+      
+      //fallback to the first debug configuration that is a c++ debugger
       for (let i = 0; i < wpLaunchConfigs.length; ++i) {
         if (this.IsCCppDebugger(wpLaunchConfigs[i])) {
           const debugConfig: vscode.DebugConfiguration = Object.assign({}, wpLaunchConfigs[i], {
@@ -59,7 +77,9 @@ export default class VscodeSettingsProvider implements SettingsProvider {
           return debugConfig;
         }
       }
+      
     }
+    
     return "";
   }
 


### PR DESCRIPTION
This will fix #47.

I also added a devcontainer so those of us checking it out can get a prebuilt environment with node/npm/typescript installed.