### PR TITLE
Add support for `cpputestTestAdapter.preLaunchTask` setting    

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To let this plugin know where your tests are set the ```cpputestTestAdapter.test
 ```
 They will be executed in the ```cpputestTestAdapter.testExecutablePath``` path.
 
+To arrange for a task to be run prior to running tests or refreshing the test list, set ```cpputestTestAdapter.preLaunchTask``` to the name of a task from tasks.json. This can be used to rebuild the test executable, for example.
+
 If you want to use the debugging functions you will also need to setup a launch.json file with your debugger path and arguments etc. The adapter will take care of the rest. Hopefully.
 
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,12 @@
           "type": "string",
           "scope": "resource"
         },
+        "cpputestTestAdapter.preLaunchTask": {
+          "description": "Task to run before running the test executable",
+          "default": "",
+          "type": "string",
+          "scope": "resource"
+        },
         "cpputestTestAdapter.testLocationFetchMode": {
           "description": "",
           "default": "auto",

--- a/src/Infrastructure/SettingsProvider.ts
+++ b/src/Infrastructure/SettingsProvider.ts
@@ -11,6 +11,7 @@ export interface SettingsProvider {
   GetObjDumpPath(): string;
   GetTestRunners(): string[];
   GetTestPath(): string;
+  GetPreLaunchTask(): string;
   get TestLocationFetchMode(): TestLocationFetchMode;
   GetDebugConfiguration(): (DebugConfiguration | string);
   GetWorkspaceFolders(): readonly WorkspaceFolder[] | undefined

--- a/src/Infrastructure/VscodeSettingsProvider.ts
+++ b/src/Infrastructure/VscodeSettingsProvider.ts
@@ -33,6 +33,10 @@ export default class VscodeSettingsProvider implements SettingsProvider {
     return this.ResolveSettingsVariable(this.config.testExecutablePath);
   }
 
+  public GetPreLaunchTask(): string {
+    return this.config.preLaunchTask;
+  }
+
   public get TestLocationFetchMode(): TestLocationFetchMode {
     switch(this.config.testLocationFetchMode) {
       case 'test query':

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -72,7 +72,7 @@ export class CppUTestAdapter implements TestAdapter {
 		this.testStatesEmitter.fire(<TestRunStartedEvent>{ type: 'started', tests });
 		this.log.info('Running tests');
 		await this.updateTests();
-		if (tests.length == 1 && tests[0] == this.mainSuite.id) {
+		if (tests.length == 1 && tests[0] == this.mainSuite.id || tests[0] == 'error') {
 			await this.root.RunAllTests();
 		} else {
 			await this.root.RunTest(...tests);


### PR DESCRIPTION
The configured task will be run at the beginning of `load()`, `run()`, and `debug()`. This can be used to rebuild the test executable.

Addresses issue #42

One minor issue I ran into is that when first opening a CMake project with `"cmake.configureOnOpen": true`, there's a race that leads to an error popup, "Configuration is already in progress". The only way to solve this that I have found is to set `cmake.configureOnOpen` to `false`, and to make the CMake Build task in `tasks.json` depend on the CMake Configure task. It works, but it creates a little bit of latency in various operations and requires creating custom tasks instead of being able to rely on the default templates from CMake Tools.

If the task process returns a nonzero error code, that will be reported by emitting a `TestLoadFinishedEvent` event with an `errorMessage` instead of a `suite`. 
![image](https://github.com/user-attachments/assets/c1b6aaed-e201-4101-b02c-6b8646889d2c)
![image](https://github.com/user-attachments/assets/a40a2999-db57-4ef1-9b3d-8b308aa61602)

This required some changes to how `run()` decides which tests to run. If you're interested, I can submit another PR that uses the `errorMessage` feature to report test runner failures as well instead of `CreateTestSuiteError()`, if you're interested. Conversely, if you'd rather I mimic `CreateTestSuiteError()` instead for this PR, I'd be happy to make that change.