### PR TITLE
Update type signatures to match latest Node.js child_process

### DIFF
--- a/src/Application/NodeProcessExecuter.ts
+++ b/src/Application/NodeProcessExecuter.ts
@@ -1,7 +1,7 @@
 import { ProcessExecuter } from "./ProcessExecuter";
-import { exec, execFile, ChildProcess, ExecException } from "child_process";
+import { exec, execFile, ChildProcess, ExecFileException } from "child_process";
 
-type execCallbackType = (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void;
+type execCallbackType = (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void;
 
 export class NodeProcessExecuter implements ProcessExecuter {
     public readonly Exec: Function;

--- a/tests/ExecutableRunner.spec.ts
+++ b/tests/ExecutableRunner.spec.ts
@@ -39,7 +39,7 @@ class ExecError implements ExecException {
   cmd?: string;
   killed?: boolean;
   code?: number;
-  signal?: string;
+  signal?: NodeJS.Signals;
   constructor(code?: number) {
     this.code = code;
   }


### PR DESCRIPTION
Two incompatible changes to the typing metadata in `child_process` related to `ExecException` are causing my build to break.

References:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51002
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40560