### PR TITLE
Readme logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ They will be executed in the ```cpputestTestAdapter.testExecutablePath``` path.
 
 To arrange for a task to be run prior to running tests or refreshing the test list, set ```cpputestTestAdapter.preLaunchTask``` to the name of a task from tasks.json. This can be used to rebuild the test executable, for example.
 
+### Logging Configuration
+
+To enable debugging and troubleshooting, configure the logging options:
+```json
+{
+  "cpputestTestAdapter.logpanel": true,
+  "cpputestTestAdapter.logfile": "${workspaceFolder}/logs/cpputest-adapter.log"
+}
+```
+
+- ```logpanel```: Shows logs in VSCode's Output panel ("CppUTest Test Adapter Log")
+- ```logfile```: Saves logs to a file. Recommended extensions: ```.log```, ```.txt```
+
 If you want to use the debugging functions you will also need to setup a launch.json file with your debugger path and arguments etc. The adapter will take care of the rest. Hopefully.
 
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ To enable debugging and troubleshooting, configure the logging options:
 ```json
 {
   "cpputestTestAdapter.logpanel": true,
-  "cpputestTestAdapter.logfile": "${workspaceFolder}/logs/cpputest-adapter.log"
+  "cpputestTestAdapter.logfile": "C:/temp/cpputest-adapter.log"
 }
 ```
 
 - ```logpanel```: Shows logs in VSCode's Output panel ("CppUTest Test Adapter Log")
-- ```logfile```: Saves logs to a file. Recommended extensions: ```.log```, ```.txt```
+- ```logfile```: Saves logs to a file. Use absolute paths (variables like ```${workspaceFolder}``` are not supported). Create the directory beforehand if it doesn't exist.
 
 If you want to use the debugging functions you will also need to setup a launch.json file with your debugger path and arguments etc. The adapter will take care of the rest. Hopefully.
 


### PR DESCRIPTION
This pull request adds documentation to clarify how to configure logging for the CppUTest Test Adapter. The new section explains how to enable log output in the VSCode Output panel and how to save logs to a file, including important notes about file paths and directory creation.

**Documentation improvements:**

* Added a "Logging Configuration" section to `README.md` with instructions for enabling the log panel and specifying a log file, including usage examples and important caveats about path handling.