### PR TITLE
Fix/test executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ To let this plugin know where your tests are set the ```cpputestTestAdapter.test
   "cpputestTestAdapter.testExecutablePath": "${workspaceFolder}/test"
 }
 ```
-They will be executed in the ```cpputestTestAdapter.testExecutablePath``` path.
+
+Both settings support the ```${workspaceFolder}``` variable. The ```testExecutablePath``` determines the working directory:
+- If set, all test executables will be run from this directory
+- If not set, each test executable will be run from its own directory (the directory containing the executable)
 
 To arrange for a task to be run prior to running tests or refreshing the test list, set ```cpputestTestAdapter.preLaunchTask``` to the name of a task from tasks.json. This can be used to rebuild the test executable, for example.
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -145,9 +145,10 @@ export class CppUTestAdapter implements TestAdapter {
 	}
 
 	private GetExecutionOptions(): ExecutableRunnerOptions | undefined {
+		const testPath = this.settingsProvider.GetTestPath();
 		return {
 			objDumpExecutable: this.settingsProvider.GetObjDumpPath(),
-			workingDirectory: undefined // this is calculated inside the ExecutableRunner, not really good style
+			workingDirectory: testPath || undefined
 		}
 	}
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -148,7 +148,7 @@ export class CppUTestAdapter implements TestAdapter {
 		const testPath = this.settingsProvider.GetTestPath();
 		return {
 			objDumpExecutable: this.settingsProvider.GetObjDumpPath(),
-			workingDirectory: testPath || undefined
+			workingDirectory: testPath
 		}
 	}
 

--- a/tests/SettingsProvider.spec.ts
+++ b/tests/SettingsProvider.spec.ts
@@ -135,4 +135,37 @@ describe("SettingsProvider should", () => {
         const actualPath = settingsProvider.GetTestRunners()
         expect(actualPath).to.have.members(expectedPath);
     })
+
+    describe("testExecutablePath variable resolution", () => {
+        it("should resolve ${workspaceFolder} in testExecutablePath", () => {
+            const logger = mock<Log>();
+            config.testExecutablePath = "${workspaceFolder}/test";
+            const expectedPath = "myFolder/test";
+
+            const settingsProvider = new TestSettingsProvider(logger, config, filesToFind);
+
+            const actualPath = settingsProvider.GetTestPath();
+            expect(actualPath).to.equal(expectedPath);
+        });
+
+        it("should return empty string when testExecutablePath is empty", () => {
+            const logger = mock<Log>();
+            config.testExecutablePath = "";
+
+            const settingsProvider = new TestSettingsProvider(logger, config, filesToFind);
+
+            const actualPath = settingsProvider.GetTestPath();
+            expect(actualPath).to.equal("");
+        });
+
+        it("should return string as-is when no variables present", () => {
+            const logger = mock<Log>();
+            config.testExecutablePath = "/absolute/path/test";
+
+            const settingsProvider = new TestSettingsProvider(logger, config, filesToFind);
+
+            const actualPath = settingsProvider.GetTestPath();
+            expect(actualPath).to.equal("/absolute/path/test");
+        });
+    });
 });


### PR DESCRIPTION
This pull request enhances how the test execution working directory is determined and improves related documentation and test coverage. The main change is that the `testExecutablePath` setting now controls the working directory for test execution, with support for variable substitution (such as `${workspaceFolder}`), and this behavior is now clearly documented and thoroughly tested.

**Working Directory Handling Improvements**
* The `CppUTestAdapter` now sets the test execution working directory based on the `testExecutablePath` setting, defaulting to the executable's directory if not set. This ensures more predictable and configurable test runs.

**Documentation Updates**
* The `README.md` is updated to clarify how the `testExecutablePath` setting affects the working directory for test execution, including variable support and fallback behavior.

**Test Coverage Enhancements**
* New tests in `ExecutableRunner.spec.ts` verify that the working directory is correctly set according to the provided options or defaults to the executable's directory.
* Additional tests in `SettingsProvider.spec.ts` confirm that variable substitution in `testExecutablePath` works as expected and that edge cases (empty string, no variables) are handled properly.