### PR TITLE
Fixes Issue #72: Bring Plugin to cursor

### DIFF
--- a/.github/workflows/do_release.yml
+++ b/.github/workflows/do_release.yml
@@ -64,11 +64,18 @@ jobs:
           if-no-files-found: error
           path: ${{github.workspace}}/cpputest-test-adapter-${{steps.gitversion.outputs.semVer}}.vsix
 
-      - name: publish to marketplace
-        if: github.ref == 'refs/heads/master'
-        run: npm run publish-buildserver
-        env:
-            VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        id: publishToOpenVSX
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
         
       - name: create a release
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
I think in order to publish to open vsx, you would need to do the following.

I don't have a way to test it though.

Using this extension.
https://github.com/HaaLeo/publish-vscode-extension

You will have to add the OPEN_VSX_TOKEN secret